### PR TITLE
Bug # 84982 Syntax-Highlight-Engine-Kate: Support case insensitive names

### DIFF
--- a/lib/Syntax/Highlight/Engine/Kate.pm
+++ b/lib/Syntax/Highlight/Engine/Kate.pm
@@ -616,11 +616,30 @@ sub languagePropose {
 }
 
 sub languagePlug {
-	my ($self, $req) = @_;
+	my ($self, $req, $insensitive) = @_;
+
 	unless (exists($self->{'syntaxes'}->{$req})) {
-		warn "undefined language: $req";
-		return undef;
+		if (defined($insensitive) && $insensitive) {
+			my $matched = 0;
+			foreach my $key (keys(%{$self->{'syntaxes'}})) {
+				if ($key =~ /^$req$/i) {
+					warn "substituting language $key for $req";
+					$req = $key;
+					$matched = 1;
+					last;
+				}
+			}
+
+			unless ($matched) {
+				warn "undefined language: $req";
+				return undef;
+			}
+		} else {
+			warn "undefined language: $req";
+			return undef;
+		}
 	}
+
 	return $self->{'syntaxes'}->{$req};
 }
 
@@ -804,9 +823,13 @@ Suggests language name for the fiven file B<$filename>
 
 returns a list of languages for which plugins have been defined.
 
-=item B<languagePlug>(I<$language>);
+=item B<languagePlug>(I<$language>, I<?$insensitive?>);
 
-returns the module name of the plugin for B<$language>
+Returns the module name of the plugin for B<$language>.
+
+If B<$insensitive> is set it will also try to match names ignoring case and return the correct module name of the plugin.
+
+e.g. $highlighter->languagePlug('HtMl', 1); will return 'HTML'.
 
 =item B<languagePropose>(I<$filename>);
 


### PR DESCRIPTION
Add support for handling case insensitive language names when performing
syntax highlighting.
