### PR TITLE
Refer to Toolkit module and Kate repository

### DIFF
--- a/lib/Syntax/Highlight/Engine/Kate.pm
+++ b/lib/Syntax/Highlight/Engine/Kate.pm
@@ -1013,6 +1013,10 @@ that all bugs are shaken out.
  xslt                 Xslt                     No sample file
  yacas                Yacas                    No sample file
 
+Module L<Syntax::Highlight::Engine::Kate::Convert::ToolKit> and script
+L<hl-kate-convert> can be used to convert existing Kate/KTextEditor Syntax
+Highlighting file from XML format to Perl.
+
 =head1 BUGS
 
 Float is detected differently than in the Kate editor.
@@ -1060,6 +1064,8 @@ as Perl itself.
 =item * L<Syntax::Highlight::Engine::Kate::Template>
 
 =item * L<http://www.kate-editor.org>
+
+=item * L<KTextEditor Syntax Highlighting Repository|https://quickgit.kde.org/?p=ktexteditor.git&a=tree&f=src%2Fsyntax%2Fdata>
 
 =back
 

--- a/lib/Syntax/Highlight/Engine/Kate/Convert/ToolKit.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Convert/ToolKit.pm
@@ -1110,7 +1110,10 @@ especially for generating highlight definitions from Kate's originals.
 
 ToolKit module carries helper routines, notably conversion from native
 highlight definitions of Kate to the ones as used by
-Syntax::Highlight::Engine::Kate.
+L<Syntax::Highlight::Engine::Kate>.
 
 For convenience, such conversion process is wrapped into provided
-C<hl-kate-convert> script.
+L<hl-kate-convert> script.
+
+This module requires L<XML::Dumper> and L<XML::TokeParser> which are not listed
+as dependencies of Syntax::Highlight::Engine::Kate.


### PR DESCRIPTION
The module documentation should refer to where to get original highlighting definitions and how to convert them for inclusion in this project.