### PR TITLE
Fix #108893 for Syntax-Highlight-Engine-Kate: MYMETA must not be incl…

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -14,6 +14,7 @@
 \bpm_to_blib$
 \bblibdirs$
 ^MANIFEST\.SKIP$
+^MYMETA\.\w+$
 
 # Avoid Module::Build generated and utility files.
 \bBuild$


### PR DESCRIPTION
…uded

Add MYMETA.* files to MANIFEST.SKIP