### PR TITLE
Fix SYNOPSIS code: replace indirect object notation with method call syntax

### DIFF
--- a/lib/Syntax/Highlight/Engine/Kate/ABC.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ABC.pm
@@ -312,7 +312,7 @@ Syntax::Highlight::Engine::Kate::ABC - a Plugin for ABC syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ABC;
- my $sh = new Syntax::Highlight::Engine::Kate::ABC([
+ my $sh = Syntax::Highlight::Engine::Kate::ABC->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/AHDL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/AHDL.pm
@@ -395,7 +395,7 @@ Syntax::Highlight::Engine::Kate::AHDL - a Plugin for AHDL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::AHDL;
- my $sh = new Syntax::Highlight::Engine::Kate::AHDL([
+ my $sh = Syntax::Highlight::Engine::Kate::AHDL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ANSI_C89.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ANSI_C89.pm
@@ -488,7 +488,7 @@ Syntax::Highlight::Engine::Kate::ANSI_C89 - a Plugin for ANSI C89 syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ANSI_C89;
- my $sh = new Syntax::Highlight::Engine::Kate::ANSI_C89([
+ my $sh = Syntax::Highlight::Engine::Kate::ANSI_C89->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ASP.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ASP.pm
@@ -1032,7 +1032,7 @@ Syntax::Highlight::Engine::Kate::ASP - a Plugin for ASP syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ASP;
- my $sh = new Syntax::Highlight::Engine::Kate::ASP([
+ my $sh = Syntax::Highlight::Engine::Kate::ASP->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/AVR_Assembler.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/AVR_Assembler.pm
@@ -365,7 +365,7 @@ Syntax::Highlight::Engine::Kate::AVR_Assembler - a Plugin for AVR Assembler synt
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::AVR_Assembler;
- my $sh = new Syntax::Highlight::Engine::Kate::AVR_Assembler([
+ my $sh = Syntax::Highlight::Engine::Kate::AVR_Assembler->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/AWK.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/AWK.pm
@@ -249,7 +249,7 @@ Syntax::Highlight::Engine::Kate::AWK - a Plugin for AWK syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::AWK;
- my $sh = new Syntax::Highlight::Engine::Kate::AWK([
+ my $sh = Syntax::Highlight::Engine::Kate::AWK->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Ada.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Ada.pm
@@ -293,7 +293,7 @@ Syntax::Highlight::Engine::Kate::Ada - a Plugin for Ada syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Ada;
- my $sh = new Syntax::Highlight::Engine::Kate::Ada([
+ my $sh = Syntax::Highlight::Engine::Kate::Ada->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Alerts.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Alerts.pm
@@ -78,7 +78,7 @@ Syntax::Highlight::Engine::Kate::Alerts - a Plugin for Alerts syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Alerts;
- my $sh = new Syntax::Highlight::Engine::Kate::Alerts([
+ my $sh = Syntax::Highlight::Engine::Kate::Alerts->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Ansys.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Ansys.pm
@@ -2314,7 +2314,7 @@ Syntax::Highlight::Engine::Kate::Ansys - a Plugin for Ansys syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Ansys;
- my $sh = new Syntax::Highlight::Engine::Kate::Ansys([
+ my $sh = Syntax::Highlight::Engine::Kate::Ansys->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Apache_Configuration.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Apache_Configuration.pm
@@ -818,7 +818,7 @@ Syntax::Highlight::Engine::Kate::Apache_Configuration - a Plugin for Apache Conf
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Apache_Configuration;
- my $sh = new Syntax::Highlight::Engine::Kate::Apache_Configuration([
+ my $sh = Syntax::Highlight::Engine::Kate::Apache_Configuration->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Asm6502.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Asm6502.pm
@@ -696,7 +696,7 @@ Syntax::Highlight::Engine::Kate::Asm6502 - a Plugin for Asm6502 syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Asm6502;
- my $sh = new Syntax::Highlight::Engine::Kate::Asm6502([
+ my $sh = Syntax::Highlight::Engine::Kate::Asm6502->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Bash.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Bash.pm
@@ -2070,7 +2070,7 @@ Syntax::Highlight::Engine::Kate::Bash - a Plugin for Bash syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Bash;
- my $sh = new Syntax::Highlight::Engine::Kate::Bash([
+ my $sh = Syntax::Highlight::Engine::Kate::Bash->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/BibTeX.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/BibTeX.pm
@@ -210,7 +210,7 @@ Syntax::Highlight::Engine::Kate::BibTeX - a Plugin for BibTeX syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::BibTeX;
- my $sh = new Syntax::Highlight::Engine::Kate::BibTeX([
+ my $sh = Syntax::Highlight::Engine::Kate::BibTeX->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/C.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/C.pm
@@ -634,7 +634,7 @@ Syntax::Highlight::Engine::Kate::C - a Plugin for C syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::C;
- my $sh = new Syntax::Highlight::Engine::Kate::C([
+ my $sh = Syntax::Highlight::Engine::Kate::C->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/CGiS.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/CGiS.pm
@@ -407,7 +407,7 @@ Syntax::Highlight::Engine::Kate::CGiS - a Plugin for CGiS syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::CGiS;
- my $sh = new Syntax::Highlight::Engine::Kate::CGiS([
+ my $sh = Syntax::Highlight::Engine::Kate::CGiS->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/CMake.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/CMake.pm
@@ -343,7 +343,7 @@ Syntax::Highlight::Engine::Kate::CMake - a Plugin for CMake syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::CMake;
- my $sh = new Syntax::Highlight::Engine::Kate::CMake([
+ my $sh = Syntax::Highlight::Engine::Kate::CMake->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/CSS.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/CSS.pm
@@ -1129,7 +1129,7 @@ Syntax::Highlight::Engine::Kate::CSS - a Plugin for CSS syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::CSS;
- my $sh = new Syntax::Highlight::Engine::Kate::CSS([
+ my $sh = Syntax::Highlight::Engine::Kate::CSS->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/CSS_PHP.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/CSS_PHP.pm
@@ -1233,7 +1233,7 @@ Syntax::Highlight::Engine::Kate::CSS_PHP - a Plugin for CSS/PHP syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::CSS_PHP;
- my $sh = new Syntax::Highlight::Engine::Kate::CSS_PHP([
+ my $sh = Syntax::Highlight::Engine::Kate::CSS_PHP->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/CUE_Sheet.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/CUE_Sheet.pm
@@ -183,7 +183,7 @@ Syntax::Highlight::Engine::Kate::CUE_Sheet - a Plugin for CUE Sheet syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::CUE_Sheet;
- my $sh = new Syntax::Highlight::Engine::Kate::CUE_Sheet([
+ my $sh = Syntax::Highlight::Engine::Kate::CUE_Sheet->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Cdash.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Cdash.pm
@@ -430,7 +430,7 @@ Syntax::Highlight::Engine::Kate::Cdash - a Plugin for C# syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Cdash;
- my $sh = new Syntax::Highlight::Engine::Kate::Cdash([
+ my $sh = Syntax::Highlight::Engine::Kate::Cdash->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Cg.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Cg.pm
@@ -579,7 +579,7 @@ Syntax::Highlight::Engine::Kate::Cg - a Plugin for Cg syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Cg;
- my $sh = new Syntax::Highlight::Engine::Kate::Cg([
+ my $sh = Syntax::Highlight::Engine::Kate::Cg->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ChangeLog.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ChangeLog.pm
@@ -122,7 +122,7 @@ Syntax::Highlight::Engine::Kate::ChangeLog - a Plugin for ChangeLog syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ChangeLog;
- my $sh = new Syntax::Highlight::Engine::Kate::ChangeLog([
+ my $sh = Syntax::Highlight::Engine::Kate::ChangeLog->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Cisco.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Cisco.pm
@@ -600,7 +600,7 @@ Syntax::Highlight::Engine::Kate::Cisco - a Plugin for Cisco syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Cisco;
- my $sh = new Syntax::Highlight::Engine::Kate::Cisco([
+ my $sh = Syntax::Highlight::Engine::Kate::Cisco->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Clipper.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Clipper.pm
@@ -906,7 +906,7 @@ Syntax::Highlight::Engine::Kate::Clipper - a Plugin for Clipper syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Clipper;
- my $sh = new Syntax::Highlight::Engine::Kate::Clipper([
+ my $sh = Syntax::Highlight::Engine::Kate::Clipper->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ColdFusion.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ColdFusion.pm
@@ -1415,7 +1415,7 @@ Syntax::Highlight::Engine::Kate::ColdFusion - a Plugin for ColdFusion syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ColdFusion;
- my $sh = new Syntax::Highlight::Engine::Kate::ColdFusion([
+ my $sh = Syntax::Highlight::Engine::Kate::ColdFusion->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Common_Lisp.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Common_Lisp.pm
@@ -1365,7 +1365,7 @@ Syntax::Highlight::Engine::Kate::Common_Lisp - a Plugin for Common Lisp syntax h
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Common_Lisp;
- my $sh = new Syntax::Highlight::Engine::Kate::Common_Lisp([
+ my $sh = Syntax::Highlight::Engine::Kate::Common_Lisp->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ComponentminusPascal.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ComponentminusPascal.pm
@@ -446,7 +446,7 @@ Syntax::Highlight::Engine::Kate::ComponentminusPascal - a Plugin for Component-P
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ComponentminusPascal;
- my $sh = new Syntax::Highlight::Engine::Kate::ComponentminusPascal([
+ my $sh = Syntax::Highlight::Engine::Kate::ComponentminusPascal->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Convert/ToolKit.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Convert/ToolKit.pm
@@ -426,7 +426,7 @@ sub pmGenerate {
 		$self->lprint("=head1 SYNOPSIS");
 		$self->lprint;
 		$self->lprint(" require Syntax::Highlight::Engine::Kate::$name;");
-		$self->lprint(" my \$sh = new Syntax::Highlight::Engine::Kate::$name([");
+		$self->lprint(" my \$sh = Syntax::Highlight::Engine::Kate::$name->new([");
 			#todotodotodotodo
 		$self->lprint(" ]);");
 		$self->lprint;
@@ -704,7 +704,7 @@ sub policy {
 sub register {
 	my ($self, $new) = @_;
 	my $reg = $self->{'registered'};
-	my $k = new Syntax::Highlight::Engine::Kate::Convert::XMLData($new);
+	my $k = Syntax::Highlight::Engine::Kate::Convert::XMLData->new($new);
 	if (defined($k)) {
 		my $name = $k->language->{'name'};
 		if (exists $reg->{$name}) {
@@ -1101,7 +1101,7 @@ especially for generating highlight definitions from Kate's originals.
   use Syntax::Highlight::Engine::Kate::Convert::ToolKit;
 
   $hlfile = "/some/path/some-lang.xml";
-  $toolkit = new Syntax::Highlight::Engine::Kate::Convert::ToolKit();
+  $toolkit = Syntax::Highlight::Engine::Kate::Convert::ToolKit->new();
   # $toolkit->outcmd = sub { ... };  # optionally redefine bare output
   $outfile = $toolkit->register($hlfile);
   $toolkit->pmGenerate($outfile);

--- a/lib/Syntax/Highlight/Engine/Kate/Cplusplus.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Cplusplus.pm
@@ -774,7 +774,7 @@ Syntax::Highlight::Engine::Kate::Cplusplus - a Plugin for C++ syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Cplusplus;
- my $sh = new Syntax::Highlight::Engine::Kate::Cplusplus([
+ my $sh = Syntax::Highlight::Engine::Kate::Cplusplus->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/D.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/D.pm
@@ -841,7 +841,7 @@ Syntax::Highlight::Engine::Kate::D - a Plugin for D syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::D;
- my $sh = new Syntax::Highlight::Engine::Kate::D([
+ my $sh = Syntax::Highlight::Engine::Kate::D->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/De_DE.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/De_DE.pm
@@ -249,7 +249,7 @@ Syntax::Highlight::Engine::Kate::De_DE - a Plugin for de_DE syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::De_DE;
- my $sh = new Syntax::Highlight::Engine::Kate::De_DE([
+ my $sh = Syntax::Highlight::Engine::Kate::De_DE->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Debian_Changelog.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Debian_Changelog.pm
@@ -181,7 +181,7 @@ Syntax::Highlight::Engine::Kate::Debian_Changelog - a Plugin for Debian Changelo
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Debian_Changelog;
- my $sh = new Syntax::Highlight::Engine::Kate::Debian_Changelog([
+ my $sh = Syntax::Highlight::Engine::Kate::Debian_Changelog->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Debian_Control.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Debian_Control.pm
@@ -291,7 +291,7 @@ Syntax::Highlight::Engine::Kate::Debian_Control - a Plugin for Debian Control sy
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Debian_Control;
- my $sh = new Syntax::Highlight::Engine::Kate::Debian_Control([
+ my $sh = Syntax::Highlight::Engine::Kate::Debian_Control->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Desktop.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Desktop.pm
@@ -115,7 +115,7 @@ Syntax::Highlight::Engine::Kate::Desktop - a Plugin for .desktop syntax highligh
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Desktop;
- my $sh = new Syntax::Highlight::Engine::Kate::Desktop([
+ my $sh = Syntax::Highlight::Engine::Kate::Desktop->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Diff.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Diff.pm
@@ -137,7 +137,7 @@ Syntax::Highlight::Engine::Kate::Diff - a Plugin for Diff syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Diff;
- my $sh = new Syntax::Highlight::Engine::Kate::Diff([
+ my $sh = Syntax::Highlight::Engine::Kate::Diff->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Doxygen.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Doxygen.pm
@@ -1129,7 +1129,7 @@ Syntax::Highlight::Engine::Kate::Doxygen - a Plugin for Doxygen syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Doxygen;
- my $sh = new Syntax::Highlight::Engine::Kate::Doxygen([
+ my $sh = Syntax::Highlight::Engine::Kate::Doxygen->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/E_Language.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/E_Language.pm
@@ -430,7 +430,7 @@ Syntax::Highlight::Engine::Kate::E_Language - a Plugin for E Language syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::E_Language;
- my $sh = new Syntax::Highlight::Engine::Kate::E_Language([
+ my $sh = Syntax::Highlight::Engine::Kate::E_Language->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Eiffel.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Eiffel.pm
@@ -213,7 +213,7 @@ Syntax::Highlight::Engine::Kate::Eiffel - a Plugin for Eiffel syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Eiffel;
- my $sh = new Syntax::Highlight::Engine::Kate::Eiffel([
+ my $sh = Syntax::Highlight::Engine::Kate::Eiffel->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Email.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Email.pm
@@ -481,7 +481,7 @@ Syntax::Highlight::Engine::Kate::Email - a Plugin for Email syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Email;
- my $sh = new Syntax::Highlight::Engine::Kate::Email([
+ my $sh = Syntax::Highlight::Engine::Kate::Email->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/En_US.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/En_US.pm
@@ -250,7 +250,7 @@ Syntax::Highlight::Engine::Kate::En_US - a Plugin for en_US syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::En_US;
- my $sh = new Syntax::Highlight::Engine::Kate::En_US([
+ my $sh = Syntax::Highlight::Engine::Kate::En_US->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Euphoria.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Euphoria.pm
@@ -541,7 +541,7 @@ Syntax::Highlight::Engine::Kate::Euphoria - a Plugin for Euphoria syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Euphoria;
- my $sh = new Syntax::Highlight::Engine::Kate::Euphoria([
+ my $sh = Syntax::Highlight::Engine::Kate::Euphoria->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Ferite.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Ferite.pm
@@ -444,7 +444,7 @@ Syntax::Highlight::Engine::Kate::Ferite - a Plugin for ferite syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Ferite;
- my $sh = new Syntax::Highlight::Engine::Kate::Ferite([
+ my $sh = Syntax::Highlight::Engine::Kate::Ferite->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Fortran.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Fortran.pm
@@ -1170,7 +1170,7 @@ Syntax::Highlight::Engine::Kate::Fortran - a Plugin for Fortran syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Fortran;
- my $sh = new Syntax::Highlight::Engine::Kate::Fortran([
+ my $sh = Syntax::Highlight::Engine::Kate::Fortran->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/FourGL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/FourGL.pm
@@ -338,7 +338,7 @@ Syntax::Highlight::Engine::Kate::FourGL - a Plugin for 4GL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::FourGL;
- my $sh = new Syntax::Highlight::Engine::Kate::FourGL([
+ my $sh = Syntax::Highlight::Engine::Kate::FourGL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/FourGLminusPER.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/FourGLminusPER.pm
@@ -154,7 +154,7 @@ Syntax::Highlight::Engine::Kate::FourGLminusPER - a Plugin for 4GL-PER syntax hi
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::FourGLminusPER;
- my $sh = new Syntax::Highlight::Engine::Kate::FourGLminusPER([
+ my $sh = Syntax::Highlight::Engine::Kate::FourGLminusPER->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/FreeBASIC.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/FreeBASIC.pm
@@ -856,7 +856,7 @@ Syntax::Highlight::Engine::Kate::FreeBASIC - a Plugin for FreeBASIC syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::FreeBASIC;
- my $sh = new Syntax::Highlight::Engine::Kate::FreeBASIC([
+ my $sh = Syntax::Highlight::Engine::Kate::FreeBASIC->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/GDL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/GDL.pm
@@ -1182,7 +1182,7 @@ Syntax::Highlight::Engine::Kate::GDL - a Plugin for GDL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::GDL;
- my $sh = new Syntax::Highlight::Engine::Kate::GDL([
+ my $sh = Syntax::Highlight::Engine::Kate::GDL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/GLSL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/GLSL.pm
@@ -485,7 +485,7 @@ Syntax::Highlight::Engine::Kate::GLSL - a Plugin for GLSL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::GLSL;
- my $sh = new Syntax::Highlight::Engine::Kate::GLSL([
+ my $sh = Syntax::Highlight::Engine::Kate::GLSL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/GNU_Assembler.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/GNU_Assembler.pm
@@ -426,7 +426,7 @@ Syntax::Highlight::Engine::Kate::GNU_Assembler - a Plugin for GNU Assembler synt
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::GNU_Assembler;
- my $sh = new Syntax::Highlight::Engine::Kate::GNU_Assembler([
+ my $sh = Syntax::Highlight::Engine::Kate::GNU_Assembler->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/GNU_Gettext.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/GNU_Gettext.pm
@@ -151,7 +151,7 @@ Syntax::Highlight::Engine::Kate::GNU_Gettext - a Plugin for GNU Gettext syntax h
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::GNU_Gettext;
- my $sh = new Syntax::Highlight::Engine::Kate::GNU_Gettext([
+ my $sh = Syntax::Highlight::Engine::Kate::GNU_Gettext->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/HTML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/HTML.pm
@@ -906,7 +906,7 @@ Syntax::Highlight::Engine::Kate::HTML - a Plugin for HTML syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::HTML;
- my $sh = new Syntax::Highlight::Engine::Kate::HTML([
+ my $sh = Syntax::Highlight::Engine::Kate::HTML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Haskell.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Haskell.pm
@@ -572,7 +572,7 @@ Syntax::Highlight::Engine::Kate::Haskell - a Plugin for Haskell syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Haskell;
- my $sh = new Syntax::Highlight::Engine::Kate::Haskell([
+ my $sh = Syntax::Highlight::Engine::Kate::Haskell->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/IDL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/IDL.pm
@@ -376,7 +376,7 @@ Syntax::Highlight::Engine::Kate::IDL - a Plugin for IDL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::IDL;
- my $sh = new Syntax::Highlight::Engine::Kate::IDL([
+ my $sh = Syntax::Highlight::Engine::Kate::IDL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ILERPG.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ILERPG.pm
@@ -523,7 +523,7 @@ Syntax::Highlight::Engine::Kate::ILERPG - a Plugin for ILERPG syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ILERPG;
- my $sh = new Syntax::Highlight::Engine::Kate::ILERPG([
+ my $sh = Syntax::Highlight::Engine::Kate::ILERPG->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/INI_Files.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/INI_Files.pm
@@ -188,7 +188,7 @@ Syntax::Highlight::Engine::Kate::INI_Files - a Plugin for INI Files syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::INI_Files;
- my $sh = new Syntax::Highlight::Engine::Kate::INI_Files([
+ my $sh = Syntax::Highlight::Engine::Kate::INI_Files->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Inform.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Inform.pm
@@ -802,7 +802,7 @@ Syntax::Highlight::Engine::Kate::Inform - a Plugin for Inform syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Inform;
- my $sh = new Syntax::Highlight::Engine::Kate::Inform([
+ my $sh = Syntax::Highlight::Engine::Kate::Inform->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Intel_x86_NASM.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Intel_x86_NASM.pm
@@ -1448,7 +1448,7 @@ Syntax::Highlight::Engine::Kate::Intel_x86_NASM - a Plugin for Intel x86 (NASM) 
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Intel_x86_NASM;
- my $sh = new Syntax::Highlight::Engine::Kate::Intel_x86_NASM([
+ my $sh = Syntax::Highlight::Engine::Kate::Intel_x86_NASM->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/JSP.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/JSP.pm
@@ -4151,7 +4151,7 @@ Syntax::Highlight::Engine::Kate::JSP - a Plugin for JSP syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::JSP;
- my $sh = new Syntax::Highlight::Engine::Kate::JSP([
+ my $sh = Syntax::Highlight::Engine::Kate::JSP->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Java.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Java.pm
@@ -3818,7 +3818,7 @@ Syntax::Highlight::Engine::Kate::Java - a Plugin for Java syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Java;
- my $sh = new Syntax::Highlight::Engine::Kate::Java([
+ my $sh = Syntax::Highlight::Engine::Kate::Java->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/JavaScript.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/JavaScript.pm
@@ -899,7 +899,7 @@ Syntax::Highlight::Engine::Kate::JavaScript - a Plugin for JavaScript syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::JavaScript;
- my $sh = new Syntax::Highlight::Engine::Kate::JavaScript([
+ my $sh = Syntax::Highlight::Engine::Kate::JavaScript->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/JavaScript_PHP.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/JavaScript_PHP.pm
@@ -969,7 +969,7 @@ Syntax::Highlight::Engine::Kate::JavaScript_PHP - a Plugin for JavaScript/PHP sy
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::JavaScript_PHP;
- my $sh = new Syntax::Highlight::Engine::Kate::JavaScript_PHP([
+ my $sh = Syntax::Highlight::Engine::Kate::JavaScript_PHP->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Javadoc.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Javadoc.pm
@@ -627,7 +627,7 @@ Syntax::Highlight::Engine::Kate::Javadoc - a Plugin for Javadoc syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Javadoc;
- my $sh = new Syntax::Highlight::Engine::Kate::Javadoc([
+ my $sh = Syntax::Highlight::Engine::Kate::Javadoc->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/KBasic.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/KBasic.pm
@@ -193,7 +193,7 @@ Syntax::Highlight::Engine::Kate::KBasic - a Plugin for KBasic syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::KBasic;
- my $sh = new Syntax::Highlight::Engine::Kate::KBasic([
+ my $sh = Syntax::Highlight::Engine::Kate::KBasic->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Kate_File_Template.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Kate_File_Template.pm
@@ -233,7 +233,7 @@ Syntax::Highlight::Engine::Kate::Kate_File_Template - a Plugin for Kate File Tem
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Kate_File_Template;
- my $sh = new Syntax::Highlight::Engine::Kate::Kate_File_Template([
+ my $sh = Syntax::Highlight::Engine::Kate::Kate_File_Template->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/LDIF.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/LDIF.pm
@@ -511,7 +511,7 @@ Syntax::Highlight::Engine::Kate::LDIF - a Plugin for LDIF syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::LDIF;
- my $sh = new Syntax::Highlight::Engine::Kate::LDIF([
+ my $sh = Syntax::Highlight::Engine::Kate::LDIF->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/LPC.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/LPC.pm
@@ -454,7 +454,7 @@ Syntax::Highlight::Engine::Kate::LPC - a Plugin for LPC syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::LPC;
- my $sh = new Syntax::Highlight::Engine::Kate::LPC([
+ my $sh = Syntax::Highlight::Engine::Kate::LPC->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/LaTeX.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/LaTeX.pm
@@ -695,7 +695,7 @@ Syntax::Highlight::Engine::Kate::LaTeX - a Plugin for LaTeX syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::LaTeX;
- my $sh = new Syntax::Highlight::Engine::Kate::LaTeX([
+ my $sh = Syntax::Highlight::Engine::Kate::LaTeX->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Lex_Flex.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Lex_Flex.pm
@@ -618,7 +618,7 @@ Syntax::Highlight::Engine::Kate::Lex_Flex - a Plugin for Lex/Flex syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Lex_Flex;
- my $sh = new Syntax::Highlight::Engine::Kate::Lex_Flex([
+ my $sh = Syntax::Highlight::Engine::Kate::Lex_Flex->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/LilyPond.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/LilyPond.pm
@@ -2110,7 +2110,7 @@ Syntax::Highlight::Engine::Kate::LilyPond - a Plugin for LilyPond syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::LilyPond;
- my $sh = new Syntax::Highlight::Engine::Kate::LilyPond([
+ my $sh = Syntax::Highlight::Engine::Kate::LilyPond->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Literate_Haskell.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Literate_Haskell.pm
@@ -591,7 +591,7 @@ Syntax::Highlight::Engine::Kate::Literate_Haskell - a Plugin for Literate Haskel
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Literate_Haskell;
- my $sh = new Syntax::Highlight::Engine::Kate::Literate_Haskell([
+ my $sh = Syntax::Highlight::Engine::Kate::Literate_Haskell->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Logtalk.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Logtalk.pm
@@ -885,7 +885,7 @@ Syntax::Highlight::Engine::Kate::Logtalk - a Plugin for Logtalk syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Logtalk;
- my $sh = new Syntax::Highlight::Engine::Kate::Logtalk([
+ my $sh = Syntax::Highlight::Engine::Kate::Logtalk->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Lua.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Lua.pm
@@ -350,7 +350,7 @@ Syntax::Highlight::Engine::Kate::Lua - a Plugin for Lua syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Lua;
- my $sh = new Syntax::Highlight::Engine::Kate::Lua([
+ my $sh = Syntax::Highlight::Engine::Kate::Lua->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/M3U.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/M3U.pm
@@ -109,7 +109,7 @@ Syntax::Highlight::Engine::Kate::M3U - a Plugin for M3U syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::M3U;
- my $sh = new Syntax::Highlight::Engine::Kate::M3U([
+ my $sh = Syntax::Highlight::Engine::Kate::M3U->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/MABminusDB.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/MABminusDB.pm
@@ -131,7 +131,7 @@ Syntax::Highlight::Engine::Kate::MABminusDB - a Plugin for MAB-DB syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::MABminusDB;
- my $sh = new Syntax::Highlight::Engine::Kate::MABminusDB([
+ my $sh = Syntax::Highlight::Engine::Kate::MABminusDB->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/MIPS_Assembler.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/MIPS_Assembler.pm
@@ -516,7 +516,7 @@ Syntax::Highlight::Engine::Kate::MIPS_Assembler - a Plugin for MIPS Assembler sy
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::MIPS_Assembler;
- my $sh = new Syntax::Highlight::Engine::Kate::MIPS_Assembler([
+ my $sh = Syntax::Highlight::Engine::Kate::MIPS_Assembler->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Makefile.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Makefile.pm
@@ -282,7 +282,7 @@ Syntax::Highlight::Engine::Kate::Makefile - a Plugin for Makefile syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Makefile;
- my $sh = new Syntax::Highlight::Engine::Kate::Makefile([
+ my $sh = Syntax::Highlight::Engine::Kate::Makefile->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Mason.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Mason.pm
@@ -715,7 +715,7 @@ Syntax::Highlight::Engine::Kate::Mason - a Plugin for Mason syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Mason;
- my $sh = new Syntax::Highlight::Engine::Kate::Mason([
+ my $sh = Syntax::Highlight::Engine::Kate::Mason->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Matlab.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Matlab.pm
@@ -273,7 +273,7 @@ Syntax::Highlight::Engine::Kate::Matlab - a Plugin for Matlab syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Matlab;
- my $sh = new Syntax::Highlight::Engine::Kate::Matlab([
+ my $sh = Syntax::Highlight::Engine::Kate::Matlab->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Modulaminus2.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Modulaminus2.pm
@@ -344,7 +344,7 @@ Syntax::Highlight::Engine::Kate::Modulaminus2 - a Plugin for Modula-2 syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Modulaminus2;
- my $sh = new Syntax::Highlight::Engine::Kate::Modulaminus2([
+ my $sh = Syntax::Highlight::Engine::Kate::Modulaminus2->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Music_Publisher.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Music_Publisher.pm
@@ -1809,7 +1809,7 @@ Syntax::Highlight::Engine::Kate::Music_Publisher - a Plugin for Music Publisher 
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Music_Publisher;
- my $sh = new Syntax::Highlight::Engine::Kate::Music_Publisher([
+ my $sh = Syntax::Highlight::Engine::Kate::Music_Publisher->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Nl.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Nl.pm
@@ -250,7 +250,7 @@ Syntax::Highlight::Engine::Kate::Nl - a Plugin for nl syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Nl;
- my $sh = new Syntax::Highlight::Engine::Kate::Nl([
+ my $sh = Syntax::Highlight::Engine::Kate::Nl->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Objective_Caml.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Objective_Caml.pm
@@ -364,7 +364,7 @@ Syntax::Highlight::Engine::Kate::Objective_Caml - a Plugin for Objective Caml sy
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Objective_Caml;
- my $sh = new Syntax::Highlight::Engine::Kate::Objective_Caml([
+ my $sh = Syntax::Highlight::Engine::Kate::Objective_Caml->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/ObjectiveminusC.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/ObjectiveminusC.pm
@@ -423,7 +423,7 @@ Syntax::Highlight::Engine::Kate::ObjectiveminusC - a Plugin for Objective-C synt
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::ObjectiveminusC;
- my $sh = new Syntax::Highlight::Engine::Kate::ObjectiveminusC([
+ my $sh = Syntax::Highlight::Engine::Kate::ObjectiveminusC->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Octave.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Octave.pm
@@ -2534,7 +2534,7 @@ Syntax::Highlight::Engine::Kate::Octave - a Plugin for Octave syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Octave;
- my $sh = new Syntax::Highlight::Engine::Kate::Octave([
+ my $sh = Syntax::Highlight::Engine::Kate::Octave->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/PHP_HTML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/PHP_HTML.pm
@@ -1056,7 +1056,7 @@ Syntax::Highlight::Engine::Kate::PHP_HTML - a Plugin for PHP (HTML) syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::PHP_HTML;
- my $sh = new Syntax::Highlight::Engine::Kate::PHP_HTML([
+ my $sh = Syntax::Highlight::Engine::Kate::PHP_HTML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/PHP_PHP.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/PHP_PHP.pm
@@ -6858,7 +6858,7 @@ Syntax::Highlight::Engine::Kate::PHP_PHP - a Plugin for PHP/PHP syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::PHP_PHP;
- my $sh = new Syntax::Highlight::Engine::Kate::PHP_PHP([
+ my $sh = Syntax::Highlight::Engine::Kate::PHP_PHP->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/POVminusRay.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/POVminusRay.pm
@@ -1202,7 +1202,7 @@ Syntax::Highlight::Engine::Kate::POVminusRay - a Plugin for POV-Ray syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::POVminusRay;
- my $sh = new Syntax::Highlight::Engine::Kate::POVminusRay([
+ my $sh = Syntax::Highlight::Engine::Kate::POVminusRay->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Pascal.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Pascal.pm
@@ -416,7 +416,7 @@ Syntax::Highlight::Engine::Kate::Pascal - a Plugin for Pascal syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Pascal;
- my $sh = new Syntax::Highlight::Engine::Kate::Pascal([
+ my $sh = Syntax::Highlight::Engine::Kate::Pascal->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Perl.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Perl.pm
@@ -2916,7 +2916,7 @@ Syntax::Highlight::Engine::Kate::Perl - a Plugin for Perl syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Perl;
- my $sh = new Syntax::Highlight::Engine::Kate::Perl([
+ my $sh = Syntax::Highlight::Engine::Kate::Perl->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Perl6.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Perl6.pm
@@ -2904,7 +2904,7 @@ Syntax::Highlight::Engine::Kate::Perl6 - a Plugin for Perl 6 syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Perl6;
- my $sh = new Syntax::Highlight::Engine::Kate::Perl6([
+ my $sh = Syntax::Highlight::Engine::Kate::Perl6->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/PicAsm.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/PicAsm.pm
@@ -742,7 +742,7 @@ Syntax::Highlight::Engine::Kate::PicAsm - a Plugin for PicAsm syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::PicAsm;
- my $sh = new Syntax::Highlight::Engine::Kate::PicAsm([
+ my $sh = Syntax::Highlight::Engine::Kate::PicAsm->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Pike.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Pike.pm
@@ -445,7 +445,7 @@ Syntax::Highlight::Engine::Kate::Pike - a Plugin for Pike syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Pike;
- my $sh = new Syntax::Highlight::Engine::Kate::Pike([
+ my $sh = Syntax::Highlight::Engine::Kate::Pike->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/PostScript.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/PostScript.pm
@@ -545,7 +545,7 @@ Syntax::Highlight::Engine::Kate::PostScript - a Plugin for PostScript syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::PostScript;
- my $sh = new Syntax::Highlight::Engine::Kate::PostScript([
+ my $sh = Syntax::Highlight::Engine::Kate::PostScript->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Progress.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Progress.pm
@@ -1827,7 +1827,7 @@ Syntax::Highlight::Engine::Kate::Progress - a Plugin for progress syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Progress;
- my $sh = new Syntax::Highlight::Engine::Kate::Progress([
+ my $sh = Syntax::Highlight::Engine::Kate::Progress->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Prolog.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Prolog.pm
@@ -391,7 +391,7 @@ Syntax::Highlight::Engine::Kate::Prolog - a Plugin for Prolog syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Prolog;
- my $sh = new Syntax::Highlight::Engine::Kate::Prolog([
+ my $sh = Syntax::Highlight::Engine::Kate::Prolog->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/PureBasic.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/PureBasic.pm
@@ -1216,7 +1216,7 @@ Syntax::Highlight::Engine::Kate::PureBasic - a Plugin for PureBasic syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::PureBasic;
- my $sh = new Syntax::Highlight::Engine::Kate::PureBasic([
+ my $sh = Syntax::Highlight::Engine::Kate::PureBasic->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Python.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Python.pm
@@ -575,7 +575,7 @@ Syntax::Highlight::Engine::Kate::Python - a Plugin for Python syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Python;
- my $sh = new Syntax::Highlight::Engine::Kate::Python([
+ my $sh = Syntax::Highlight::Engine::Kate::Python->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Quake_Script.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Quake_Script.pm
@@ -2471,7 +2471,7 @@ Syntax::Highlight::Engine::Kate::Quake_Script - a Plugin for Quake Script syntax
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Quake_Script;
- my $sh = new Syntax::Highlight::Engine::Kate::Quake_Script([
+ my $sh = Syntax::Highlight::Engine::Kate::Quake_Script->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/REXX.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/REXX.pm
@@ -287,7 +287,7 @@ Syntax::Highlight::Engine::Kate::REXX - a Plugin for REXX syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::REXX;
- my $sh = new Syntax::Highlight::Engine::Kate::REXX([
+ my $sh = Syntax::Highlight::Engine::Kate::REXX->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/RPM_Spec.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/RPM_Spec.pm
@@ -215,7 +215,7 @@ Syntax::Highlight::Engine::Kate::RPM_Spec - a Plugin for RPM Spec syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::RPM_Spec;
- my $sh = new Syntax::Highlight::Engine::Kate::RPM_Spec([
+ my $sh = Syntax::Highlight::Engine::Kate::RPM_Spec->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/RSI_IDL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/RSI_IDL.pm
@@ -635,7 +635,7 @@ Syntax::Highlight::Engine::Kate::RSI_IDL - a Plugin for RSI IDL syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::RSI_IDL;
- my $sh = new Syntax::Highlight::Engine::Kate::RSI_IDL([
+ my $sh = Syntax::Highlight::Engine::Kate::RSI_IDL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/R_Script.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/R_Script.pm
@@ -166,7 +166,7 @@ Syntax::Highlight::Engine::Kate::R_Script - a Plugin for R Script syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::R_Script;
- my $sh = new Syntax::Highlight::Engine::Kate::R_Script([
+ my $sh = Syntax::Highlight::Engine::Kate::R_Script->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/RenderMan_RIB.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/RenderMan_RIB.pm
@@ -245,7 +245,7 @@ Syntax::Highlight::Engine::Kate::RenderMan_RIB - a Plugin for RenderMan RIB synt
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::RenderMan_RIB;
- my $sh = new Syntax::Highlight::Engine::Kate::RenderMan_RIB([
+ my $sh = Syntax::Highlight::Engine::Kate::RenderMan_RIB->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Ruby.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Ruby.pm
@@ -3098,7 +3098,7 @@ Syntax::Highlight::Engine::Kate::Ruby - a Plugin for Ruby syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Ruby;
- my $sh = new Syntax::Highlight::Engine::Kate::Ruby([
+ my $sh = Syntax::Highlight::Engine::Kate::Ruby->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/SGML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/SGML.pm
@@ -171,7 +171,7 @@ Syntax::Highlight::Engine::Kate::SGML - a Plugin for SGML syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::SGML;
- my $sh = new Syntax::Highlight::Engine::Kate::SGML([
+ my $sh = Syntax::Highlight::Engine::Kate::SGML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/SML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/SML.pm
@@ -222,7 +222,7 @@ Syntax::Highlight::Engine::Kate::SML - a Plugin for SML syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::SML;
- my $sh = new Syntax::Highlight::Engine::Kate::SML([
+ my $sh = Syntax::Highlight::Engine::Kate::SML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/SQL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/SQL.pm
@@ -1207,7 +1207,7 @@ Syntax::Highlight::Engine::Kate::SQL - a Plugin for SQL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::SQL;
- my $sh = new Syntax::Highlight::Engine::Kate::SQL([
+ my $sh = Syntax::Highlight::Engine::Kate::SQL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/SQL_MySQL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/SQL_MySQL.pm
@@ -688,7 +688,7 @@ Syntax::Highlight::Engine::Kate::SQL_MySQL - a Plugin for SQL (MySQL) syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::SQL_MySQL;
- my $sh = new Syntax::Highlight::Engine::Kate::SQL_MySQL([
+ my $sh = Syntax::Highlight::Engine::Kate::SQL_MySQL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/SQL_PostgreSQL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/SQL_PostgreSQL.pm
@@ -1053,7 +1053,7 @@ Syntax::Highlight::Engine::Kate::SQL_PostgreSQL - a Plugin for SQL (PostgreSQL) 
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::SQL_PostgreSQL;
- my $sh = new Syntax::Highlight::Engine::Kate::SQL_PostgreSQL([
+ my $sh = Syntax::Highlight::Engine::Kate::SQL_PostgreSQL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Sather.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Sather.pm
@@ -250,7 +250,7 @@ Syntax::Highlight::Engine::Kate::Sather - a Plugin for Sather syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Sather;
- my $sh = new Syntax::Highlight::Engine::Kate::Sather([
+ my $sh = Syntax::Highlight::Engine::Kate::Sather->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Scheme.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Scheme.pm
@@ -781,7 +781,7 @@ Syntax::Highlight::Engine::Kate::Scheme - a Plugin for Scheme syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Scheme;
- my $sh = new Syntax::Highlight::Engine::Kate::Scheme([
+ my $sh = Syntax::Highlight::Engine::Kate::Scheme->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Scilab.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Scilab.pm
@@ -1290,7 +1290,7 @@ Syntax::Highlight::Engine::Kate::Scilab - a Plugin for scilab syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Scilab;
- my $sh = new Syntax::Highlight::Engine::Kate::Scilab([
+ my $sh = Syntax::Highlight::Engine::Kate::Scilab->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Sieve.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Sieve.pm
@@ -250,7 +250,7 @@ Syntax::Highlight::Engine::Kate::Sieve - a Plugin for Sieve syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Sieve;
- my $sh = new Syntax::Highlight::Engine::Kate::Sieve([
+ my $sh = Syntax::Highlight::Engine::Kate::Sieve->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Spice.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Spice.pm
@@ -144,7 +144,7 @@ Syntax::Highlight::Engine::Kate::Spice - a Plugin for Spice syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Spice;
- my $sh = new Syntax::Highlight::Engine::Kate::Spice([
+ my $sh = Syntax::Highlight::Engine::Kate::Spice->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Stata.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Stata.pm
@@ -607,7 +607,7 @@ Syntax::Highlight::Engine::Kate::Stata - a Plugin for Stata syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Stata;
- my $sh = new Syntax::Highlight::Engine::Kate::Stata([
+ my $sh = Syntax::Highlight::Engine::Kate::Stata->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/TI_Basic.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/TI_Basic.pm
@@ -163,7 +163,7 @@ Syntax::Highlight::Engine::Kate::TI_Basic - a Plugin for TI Basic syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::TI_Basic;
- my $sh = new Syntax::Highlight::Engine::Kate::TI_Basic([
+ my $sh = Syntax::Highlight::Engine::Kate::TI_Basic->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/TaskJuggler.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/TaskJuggler.pm
@@ -575,7 +575,7 @@ Syntax::Highlight::Engine::Kate::TaskJuggler - a Plugin for TaskJuggler syntax h
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::TaskJuggler;
- my $sh = new Syntax::Highlight::Engine::Kate::TaskJuggler([
+ my $sh = Syntax::Highlight::Engine::Kate::TaskJuggler->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Tcl_Tk.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Tcl_Tk.pm
@@ -658,7 +658,7 @@ Syntax::Highlight::Engine::Kate::Tcl_Tk - a Plugin for Tcl/Tk syntax highlightin
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Tcl_Tk;
- my $sh = new Syntax::Highlight::Engine::Kate::Tcl_Tk([
+ my $sh = Syntax::Highlight::Engine::Kate::Tcl_Tk->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Txt2tags.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Txt2tags.pm
@@ -272,7 +272,7 @@ Syntax::Highlight::Engine::Kate::Txt2tags - a Plugin for txt2tags syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Txt2tags;
- my $sh = new Syntax::Highlight::Engine::Kate::Txt2tags([
+ my $sh = Syntax::Highlight::Engine::Kate::Txt2tags->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/UnrealScript.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/UnrealScript.pm
@@ -464,7 +464,7 @@ Syntax::Highlight::Engine::Kate::UnrealScript - a Plugin for UnrealScript syntax
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::UnrealScript;
- my $sh = new Syntax::Highlight::Engine::Kate::UnrealScript([
+ my $sh = Syntax::Highlight::Engine::Kate::UnrealScript->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/VHDL.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/VHDL.pm
@@ -433,7 +433,7 @@ Syntax::Highlight::Engine::Kate::VHDL - a Plugin for VHDL syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::VHDL;
- my $sh = new Syntax::Highlight::Engine::Kate::VHDL([
+ my $sh = Syntax::Highlight::Engine::Kate::VHDL->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/VRML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/VRML.pm
@@ -271,7 +271,7 @@ Syntax::Highlight::Engine::Kate::VRML - a Plugin for VRML syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::VRML;
- my $sh = new Syntax::Highlight::Engine::Kate::VRML([
+ my $sh = Syntax::Highlight::Engine::Kate::VRML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Velocity.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Velocity.pm
@@ -169,7 +169,7 @@ Syntax::Highlight::Engine::Kate::Velocity - a Plugin for Velocity syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Velocity;
- my $sh = new Syntax::Highlight::Engine::Kate::Velocity([
+ my $sh = Syntax::Highlight::Engine::Kate::Velocity->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Verilog.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Verilog.pm
@@ -539,7 +539,7 @@ Syntax::Highlight::Engine::Kate::Verilog - a Plugin for Verilog syntax highlight
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Verilog;
- my $sh = new Syntax::Highlight::Engine::Kate::Verilog([
+ my $sh = Syntax::Highlight::Engine::Kate::Verilog->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/WINE_Config.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/WINE_Config.pm
@@ -142,7 +142,7 @@ Syntax::Highlight::Engine::Kate::WINE_Config - a Plugin for WINE Config syntax h
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::WINE_Config;
- my $sh = new Syntax::Highlight::Engine::Kate::WINE_Config([
+ my $sh = Syntax::Highlight::Engine::Kate::WINE_Config->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Wikimedia.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Wikimedia.pm
@@ -517,7 +517,7 @@ Syntax::Highlight::Engine::Kate::Wikimedia - a Plugin for Wikimedia syntax highl
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Wikimedia;
- my $sh = new Syntax::Highlight::Engine::Kate::Wikimedia([
+ my $sh = Syntax::Highlight::Engine::Kate::Wikimedia->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/XHarbour.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/XHarbour.pm
@@ -800,7 +800,7 @@ Syntax::Highlight::Engine::Kate::XHarbour - a Plugin for xHarbour syntax highlig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::XHarbour;
- my $sh = new Syntax::Highlight::Engine::Kate::XHarbour([
+ my $sh = Syntax::Highlight::Engine::Kate::XHarbour->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/XML.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/XML.pm
@@ -605,7 +605,7 @@ Syntax::Highlight::Engine::Kate::XML - a Plugin for XML syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::XML;
- my $sh = new Syntax::Highlight::Engine::Kate::XML([
+ my $sh = Syntax::Highlight::Engine::Kate::XML->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/XML_Debug.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/XML_Debug.pm
@@ -2028,7 +2028,7 @@ Syntax::Highlight::Engine::Kate::XML_Debug - a Plugin for XML (Debug) syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::XML_Debug;
- my $sh = new Syntax::Highlight::Engine::Kate::XML_Debug([
+ my $sh = Syntax::Highlight::Engine::Kate::XML_Debug->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Xorg_Configuration.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Xorg_Configuration.pm
@@ -236,7 +236,7 @@ Syntax::Highlight::Engine::Kate::Xorg_Configuration - a Plugin for x.org Configu
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Xorg_Configuration;
- my $sh = new Syntax::Highlight::Engine::Kate::Xorg_Configuration([
+ my $sh = Syntax::Highlight::Engine::Kate::Xorg_Configuration->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Xslt.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Xslt.pm
@@ -795,7 +795,7 @@ Syntax::Highlight::Engine::Kate::Xslt - a Plugin for xslt syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Xslt;
- my $sh = new Syntax::Highlight::Engine::Kate::Xslt([
+ my $sh = Syntax::Highlight::Engine::Kate::Xslt->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Yacas.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Yacas.pm
@@ -383,7 +383,7 @@ Syntax::Highlight::Engine::Kate::Yacas - a Plugin for yacas syntax highlighting
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Yacas;
- my $sh = new Syntax::Highlight::Engine::Kate::Yacas([
+ my $sh = Syntax::Highlight::Engine::Kate::Yacas->new([
  ]);
 
 =head1 DESCRIPTION

--- a/lib/Syntax/Highlight/Engine/Kate/Yacc_Bison.pm
+++ b/lib/Syntax/Highlight/Engine/Kate/Yacc_Bison.pm
@@ -621,7 +621,7 @@ Syntax::Highlight::Engine::Kate::Yacc_Bison - a Plugin for Yacc/Bison syntax hig
 =head1 SYNOPSIS
 
  require Syntax::Highlight::Engine::Kate::Yacc_Bison;
- my $sh = new Syntax::Highlight::Engine::Kate::Yacc_Bison([
+ my $sh = Syntax::Highlight::Engine::Kate::Yacc_Bison->new([
  ]);
 
 =head1 DESCRIPTION


### PR DESCRIPTION
Seeing indirect object notation in sample code annoys me. So I've fixed it.

* Fixed the current versions of the file
* Also fixed Syntax::Highlight::Engine::Kate::Convert::ToolKit to do the right thing in the future